### PR TITLE
update to base template current

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -8,6 +8,6 @@
   "canonical": "http://github.com/WorldHealthOrganization/smart-ig",
   "base": "fhir.base.template",
   "dependencies": {
-    "fhir.base.template": "0.5.0"
+    "fhir.base.template": "current"
   }
 }


### PR DESCRIPTION
There seems to be a problem with getting the package for the base template 0.5.0 
To allow the builds to work, this changes the version to #current