### PR TITLE
add watermark on draft and retired IGs

### DIFF
--- a/content/assets/css/who.css
+++ b/content/assets/css/who.css
@@ -532,21 +532,20 @@ div.markdown-toc {
 #ig-status p {
   background-color: white; /* White background for the text */
   padding: 10px 17px; /* Add some padding around the text */
-  
   border-radius: 5px; /* Optional: for rounded corners */
   position: relative; /* Ensure it's above the watermark */
   z-index: 2; /* Higher z-index to be on top */
 }
 
 
-#ig-status.draft {
+#ig-status.ig-status-draft {
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='150px' height='150px'><rect width='800%' height='100%' fill='transparent' /><text transform='translate(30, 50) rotate(-35)' fill='rgba(245,45,45,0.5)' font-family='Arial' font-weight='bold' font-size='20'>DRAFT</text></svg>");
   background-size: calc(50% / 5) 100px;
   background-repeat: repeat-x;
 }
 
 
-#ig-status.retired {
+#ig-status.ig-status-retired {
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='150px' height='150px'><rect width='800%' height='100%' fill='transparent' /><text transform='translate(30, 60) rotate(-35)' fill='rgba(245,45,45,0.5)' font-family='Arial' font-weight='bold' font-size='20'>RETIRED</text></svg>");
   background-size: calc(50% / 5) 100px;
   background-repeat: repeat-x;

--- a/content/assets/css/who.css
+++ b/content/assets/css/who.css
@@ -504,26 +504,9 @@ div.markdown-toc {
 }
 
 
-
-
-
-
 #segment-footer > .container {
   background-color: var(--footer-container-bg-color) !important;
   color: var(--footer-text-color) !important;
-}
-
-#ig-status {
-  flex-grow: 1;
-  /* Grow to take the available space */
-  display: flex;
-  /* Use flex to allow child elements to center */
-  justify-content: center;
-  /* Center children horizontally */
-  align-items: center;
-  /* Center children vertically */
-  text-align: center;
-  /* Center text */
 }
 
 /* Ensure the navbar doesn't collapse into the space */
@@ -531,10 +514,40 @@ div.markdown-toc {
   flex: 1 100%;
 }
 
-/* You may want to adjust the logo image size and alignment */
-
 #segment-breadcrumb > div
 #segment-navbar >.container,
 #segment-content > div {
   padding: 0 25px;
+}
+
+#ig-status {
+  flex-grow: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  position: relative; /* Needed for layering */
+}
+
+#ig-status p {
+  background-color: white; /* White background for the text */
+  padding: 10px 17px; /* Add some padding around the text */
+  
+  border-radius: 5px; /* Optional: for rounded corners */
+  position: relative; /* Ensure it's above the watermark */
+  z-index: 2; /* Higher z-index to be on top */
+}
+
+
+#ig-status.draft {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='150px' height='150px'><rect width='800%' height='100%' fill='transparent' /><text transform='translate(30, 50) rotate(-35)' fill='rgba(245,45,45,0.5)' font-family='Arial' font-weight='bold' font-size='20'>DRAFT</text></svg>");
+  background-size: calc(50% / 5) 100px;
+  background-repeat: repeat-x;
+}
+
+
+#ig-status.retired {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='150px' height='150px'><rect width='800%' height='100%' fill='transparent' /><text transform='translate(30, 60) rotate(-35)' fill='rgba(245,45,45,0.5)' font-family='Arial' font-weight='bold' font-size='20'>RETIRED</text></svg>");
+  background-size: calc(50% / 5) 100px;
+  background-repeat: repeat-x;
 }

--- a/includes/fragment-pagebegin.html
+++ b/includes/fragment-pagebegin.html
@@ -89,7 +89,7 @@
 {% else %}
 {% assign status = site.data.fhir.ig.status %}
 {% endif %}
-        <div id="ig-status">
+        <div id="ig-status" class="{{site.data.fhir.ig.status}}">
           <p><span style="font-size:12pt;font-weight:bold">{{site.data.fhir.ig.title | escape_once}}</span>
             <br/>
             <span style="display:inline-block;">{{site.data.fhir.ig.version}} - {{status}}

--- a/includes/fragment-pagebegin.html
+++ b/includes/fragment-pagebegin.html
@@ -89,7 +89,7 @@
 {% else %}
 {% assign status = site.data.fhir.ig.status %}
 {% endif %}
-        <div id="ig-status" class="{{site.data.fhir.ig.status}}">
+        <div id="ig-status" class="ig-status-{{site.data.fhir.ig.status}}">
           <p><span style="font-size:12pt;font-weight:bold">{{site.data.fhir.ig.title | escape_once}}</span>
             <br/>
             <span style="display:inline-block;">{{site.data.fhir.ig.version}} - {{status}}


### PR DESCRIPTION
this PR adds a watermark in the top banner (except under the title) for draft or retired IGs, i.e. where the ig.status is "draft" or "retired". 
<img width="1618" alt="image" src="https://github.com/WorldHealthOrganization/smart-ig-template-who/assets/16153168/9bf43028-14ce-491d-967e-cc06cecea89b">

<img width="1620" alt="image" src="https://github.com/WorldHealthOrganization/smart-ig-template-who/assets/16153168/f60aa2ec-b811-4b1f-bd41-7347246958ea">
